### PR TITLE
Add database-defined fallback translation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $post->getTranslationModel('nl', true); // falls back to the fallback locale if 
 In case you do not supply a locale, the current locale will be used.
 
 ### Using a fallback
-This package allows you to return the value of an attribute's fallback locale. By default, the `fallback_locale` defined in `config/app.php` is used. However, you can also define fallbacks per-row on your translation tables by adding a `fallback_locale` column:
+This package allows you to return an attribute's translation value from a fallback locale when the value for the requested locale is blank or missing. By default, the `fallback_locale` defined in `config/app.php` is used. However, you can also define fallbacks per-row on your translation tables by adding a `fallback_locale` column:
 
 ```php
 PostTranslation::create(['locale' => 'en', 'title' => 'Your first translation']);

--- a/README.md
+++ b/README.md
@@ -103,21 +103,22 @@ $post->getTranslationModel('nl');
 In case you do not supply a locale, the current locale will be used.
 
 ### Using a fallback
-This package allows you to return the value of an attribute's `fallback_locale` defined in the `config/app.php` of your application.
+This package allows you to return the value of an attribute's fallback locale. By default, the `fallback_locale` defined in `config/app.php` is used. However, you can also define fallbacks per-row on your translation tables by adding a `fallback_locale` column:
 
-The third `useFallbackLocale` parameter of the `getTranslation` method may be used to control this behaviour:
 ```php
 PostTranslation::create(['locale' => 'en', 'title' => 'Your first translation']);
-PostTranslation::create(['locale' => 'nl', 'title' => null]);
+PostTranslation::create(['locale' => 'nl', 'title' => null, 'fallback_locale' => 'en']);
 
 $post->getTranslation('title', 'nl', true); // returns 'Your first translation'
 $post->getTranslation('title', 'nl', false); // returns null
 ```
 
+When a `fallback_locale` is defined on the translation model, it takes priority over the application's `fallback_locale` config value.
+
 Or you may use dedicated methods for this:
 ```php
 PostTranslation::create(['locale' => 'en', 'title' => 'Your first translation']);
-PostTranslation::create(['locale' => 'nl', 'title' => null]);
+PostTranslation::create(['locale' => 'nl', 'title' => null, 'fallback_locale' => 'en']);
 
 $post->getTranslationWithFallback('title', 'nl'); // returns 'Your first translation'
 $post->getTranslationWithoutFallback('title', 'nl'); // returns null
@@ -218,6 +219,13 @@ Post::whereTranslation('title', 'like', '%dogs%')->orWhereTranslation('title', '
 Post::translatedIn('nl');
 Post::translatedIn(['nl', 'en']);
 Post::translatedIn('nl')->orTranslatedIn('en');
+```
+
+To query models via their database-defined `fallback_locale`, you may use the fallback translation scopes:
+```php
+Post::whereFallbackTranslation('title', '<>', '');
+Post::whereTranslation('title', '=', $value, App::getLocale())
+    ->orWhereFallbackTranslation('title', '=', $value);
 ```
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ To retrieve the actual translation model you may use the `getTranslationModel` m
 ```php
 $post->getTranslationModel();
 $post->getTranslationModel('nl');
+$post->getTranslationModel('nl', true); // falls back to the fallback locale if no model exists
 ```
 
 In case you do not supply a locale, the current locale will be used.

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ $post->getTranslation('title', 'nl')
 
 To check if a translated attribute exists, you may use the `hasTranslation` method:
 ```php
-PostTranslation::create(['language' => 'en', 'title' => 'Test en', 'tags' => ['🍎', '🍐', '🍋']]);
-PostTranslation::create(['language' => 'nl', 'title' => null, 'tags' => []]);
-PostTranslation::create(['language' => 'fr', 'title' => '']);
+PostTranslation::create(['locale' => 'en', 'title' => 'Test en', 'tags' => ['🍎', '🍐', '🍋']]);
+PostTranslation::create(['locale' => 'nl', 'title' => null, 'tags' => []]);
+PostTranslation::create(['locale' => 'fr', 'title' => '']);
 
 $post->hasTranslation('title', 'en'); // returns true
 $post->hasTranslation('title', 'nl'); // returns false
@@ -88,7 +88,7 @@ $post->hasTranslation('tags', 'nl'); // returns false
 
 In case you need to check if the actual translation model exists, you may use the `hasTranslationModel` method:
 ```php
-PostTranslation::create(['language' => 'en']);
+PostTranslation::create(['locale' => 'en']);
 
 $post->hasTranslationModel('en'); // returns true
 $post->hasTranslationModel('nl'); // returns false
@@ -107,8 +107,8 @@ This package allows you to return the value of an attribute's `fallback_locale` 
 
 The third `useFallbackLocale` parameter of the `getTranslation` method may be used to control this behaviour:
 ```php
-PostTranslation::create(['language' => 'en', 'title' => 'Your first translation']);
-PostTranslation::create(['language' => 'nl', 'title' => null]);
+PostTranslation::create(['locale' => 'en', 'title' => 'Your first translation']);
+PostTranslation::create(['locale' => 'nl', 'title' => null]);
 
 $post->getTranslation('title', 'nl', true); // returns 'Your first translation'
 $post->getTranslation('title', 'nl', false); // returns null
@@ -116,8 +116,8 @@ $post->getTranslation('title', 'nl', false); // returns null
 
 Or you may use dedicated methods for this:
 ```php
-PostTranslation::create(['language' => 'en', 'title' => 'Your first translation']);
-PostTranslation::create(['language' => 'nl', 'title' => null]);
+PostTranslation::create(['locale' => 'en', 'title' => 'Your first translation']);
+PostTranslation::create(['locale' => 'nl', 'title' => null]);
 
 $post->getTranslationWithFallback('title', 'nl'); // returns 'Your first translation'
 $post->getTranslationWithoutFallback('title', 'nl'); // returns null

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -26,6 +26,14 @@ Schema::table('post_translations', function (Blueprint $table) {
 
 The `getFallbackLocale()` method now reads from the translation model's `fallback_locale` column first. If not defined, it falls back to `config('app.fallback_locale')`.
 
+Example data:
+```json
+{"id": 1, "page_id": 1, "locale": "nl-be", "fallback_locale": null, "title": "Home"}
+{"id": 2, "page_id": 1, "locale": "nl-nl", "fallback_locale": "nl-be", "title": null}
+```
+
+The main locale does not define a `fallback_locale`. Only secondary locales that need to fall back to another locale should have this column set.
+
 ### New `whereFallbackTranslation` / `orWhereFallbackTranslation` scopes
 
 Two new query scopes are available for querying models via their database-defined fallback:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,41 @@
+# Upgrading
+
+## Unreleased
+
+### Renamed `language` column to `locale`
+
+The `language` column on your translation tables should be renamed to `locale`. You can create a migration to handle this:
+
+```php
+Schema::table('post_translations', function (Blueprint $table) {
+    $table->renameColumn('language', 'locale');
+});
+```
+
+### Database-defined fallback translations
+
+Fallback translations can now be defined per-row on your translation tables using a `fallback_locale` column, instead of relying solely on the application's `fallback_locale` config value.
+
+Add the `fallback_locale` column to your translation tables:
+
+```php
+Schema::table('post_translations', function (Blueprint $table) {
+    $table->string('fallback_locale', 5)->nullable()->after('locale');
+});
+```
+
+The `getFallbackLocale()` method now reads from the translation model's `fallback_locale` column first. If not defined, it falls back to `config('app.fallback_locale')`.
+
+### New `whereFallbackTranslation` / `orWhereFallbackTranslation` scopes
+
+Two new query scopes are available for querying models via their database-defined fallback:
+
+```php
+Post::whereFallbackTranslation('title', '<>', '');
+Post::whereTranslation('title', '=', $value, App::getLocale())
+    ->orWhereFallbackTranslation('title', '=', $value);
+```
+
+### Route model binding with fallback support
+
+The `resolveRouteBinding` method now automatically resolves models via the fallback translation when no match is found for the current locale. This requires the `fallback_locale` column to be present on your translation tables.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -28,8 +28,8 @@ The `getFallbackLocale()` method now reads from the translation model's `fallbac
 
 Example data:
 ```json
-{"id": 1, "page_id": 1, "locale": "nl-be", "fallback_locale": null, "title": "Home"}
-{"id": 2, "page_id": 1, "locale": "nl-nl", "fallback_locale": "nl-be", "title": null}
+{"id": 1, "post_id": 1, "locale": "nl-be", "fallback_locale": null, "title": "Home"}
+{"id": 2, "post_id": 1, "locale": "nl-nl", "fallback_locale": "nl-be", "title": null}
 ```
 
 The main locale does not define a `fallback_locale`. Only secondary locales that need to fall back to another locale should have this column set.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -44,6 +44,15 @@ Post::whereTranslation('title', '=', $value, App::getLocale())
     ->orWhereFallbackTranslation('title', '=', $value);
 ```
 
+### `getTranslationModel` now supports fallback
+
+The `getTranslationModel` method now accepts a second `useFallbackLocale` parameter, consistent with `getTranslation`:
+
+```php
+$post->getTranslationModel('nl');        // returns null if no model exists
+$post->getTranslationModel('nl', true);  // falls back to the fallback locale's model
+```
+
 ### Route model binding with fallback support
 
 The `resolveRouteBinding` method now automatically resolves models via the fallback translation when no match is found for the current locale. This requires the `fallback_locale` column to be present on your translation tables.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,6 @@
 # Upgrading
 
-## Unreleased
+## 2.0
 
 ### Renamed `language` column to `locale`
 

--- a/src/HelperModelTranslatable.php
+++ b/src/HelperModelTranslatable.php
@@ -27,9 +27,15 @@ trait HelperModelTranslatable
         return $this->translatable ?? [];
     }
 
-    public function getTranslationModel(?string $locale = null): ?Model
+    public function getTranslationModel(?string $locale = null, bool $useFallbackLocale = false): ?Model
     {
-        return $this->{$this->helperModelRelation}->firstWhere('locale', $locale ?? App::getLocale());
+        $model = $this->{$this->helperModelRelation}->firstWhere('locale', $locale ?? App::getLocale());
+
+        if (is_null($model) && $useFallbackLocale) {
+            $model = $this->{$this->helperModelRelation}->firstWhere('locale', $this->getFallbackLocale($locale));
+        }
+
+        return $model;
     }
 
     public function hasTranslationModel(?string $locale = null): bool

--- a/src/HelperModelTranslatable.php
+++ b/src/HelperModelTranslatable.php
@@ -228,7 +228,7 @@ trait HelperModelTranslatable
                         ->on('fallback.' . $helperModelForeignKey, '=', 'base.' . $helperModelForeignKey)
                         ->on('fallback.locale', '=', 'base.fallback_locale');
                 })
-                ->whereColumn('base.' . $helperModelForeignKey, $this->qualifyColumn('id'))
+                ->whereColumn('base.' . $helperModelForeignKey, $this->getQualifiedKeyName())
                 ->where('base.locale', App::getLocale())
                 ->where(is_string($column) ? "fallback.$column" : $column, $operator, $value);
         });

--- a/src/HelperModelTranslatable.php
+++ b/src/HelperModelTranslatable.php
@@ -29,7 +29,7 @@ trait HelperModelTranslatable
 
     public function getTranslationModel(?string $locale = null): ?Model
     {
-        return $this->{$this->helperModelRelation}->firstWhere('language', $locale ?? App::getLocale());
+        return $this->{$this->helperModelRelation}->firstWhere('locale', $locale ?? App::getLocale());
     }
 
     public function hasTranslationModel(?string $locale = null): bool
@@ -42,8 +42,8 @@ trait HelperModelTranslatable
         $locale ??= App::getLocale();
         $translationModel = $this->getTranslationModel($locale);
 
-        if ($translationModel && ! blank($translationModel->fallback_language)) {
-            return $translationModel->fallback_language;
+        if ($translationModel && ! blank($translationModel->fallback_locale)) {
+            return $translationModel->fallback_locale;
         }
 
         return config('app.fallback_locale');
@@ -193,8 +193,8 @@ trait HelperModelTranslatable
     {
         return $query->when(
             is_array($locale),
-            fn (Builder $query) => $query->whereIn('language', $locale),
-            fn (Builder $query) => $query->where('language', $locale),
+            fn (Builder $query) => $query->whereIn('locale', $locale),
+            fn (Builder $query) => $query->where('locale', $locale),
         );
     }
 
@@ -220,10 +220,10 @@ trait HelperModelTranslatable
                 ->join("{$helperTable} as fallback", function (JoinClause $join) use ($helperModelForeignKey) {
                     $join
                         ->on('fallback.' . $helperModelForeignKey, '=', 'base.' . $helperModelForeignKey)
-                        ->on('fallback.language', '=', 'base.fallback_language');
+                        ->on('fallback.locale', '=', 'base.fallback_locale');
                 })
                 ->whereColumn('base.' . $helperModelForeignKey, $this->qualifyColumn('id'))
-                ->where('base.language', App::getLocale())
+                ->where('base.locale', App::getLocale())
                 ->where(is_string($column) ? "fallback.$column" : $column, $operator, $value);
         });
     }

--- a/src/HelperModelTranslatable.php
+++ b/src/HelperModelTranslatable.php
@@ -4,11 +4,14 @@ namespace Esign\HelperModelTranslatable;
 
 use Closure;
 use Esign\HelperModelTranslatable\Exceptions\InvalidConfiguration;
+use Illuminate\Contracts\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\DB;
 
 trait HelperModelTranslatable
 {
@@ -36,6 +39,13 @@ trait HelperModelTranslatable
 
     public function getFallbackLocale(?string $locale = null): ?string
     {
+        $locale ??= App::getLocale();
+        $translationModel = $this->getTranslationModel($locale);
+
+        if ($translationModel && ! blank($translationModel->fallback_language)) {
+            return $translationModel->fallback_language;
+        }
+
         return config('app.fallback_locale');
     }
 
@@ -188,6 +198,45 @@ trait HelperModelTranslatable
         );
     }
 
+    public function scopeWhereFallbackTranslation(
+        Builder $query,
+        Closure | string | array | Expression $column,
+        mixed $operator = null,
+        mixed $value = null,
+        string $boolean = 'and',
+    ): Builder {
+        $helperModelClass = $this->getHelperModelClass();
+        $helperModelForeignKey = $this->getHelperModelForeignKey();
+        /** @var \Illuminate\Database\Eloquent\Model $helperModel */
+        $helperModel = new $helperModelClass;
+        $helperTable = $helperModel->getTable();
+
+        $whereExistsStatement = $boolean === 'and' ? 'whereExists' : 'orWhereExists';
+
+        return $query->{$whereExistsStatement}(function (QueryBuilder $fallbackQuery) use ($helperTable, $helperModelForeignKey, $column, $operator, $value) {
+            $fallbackQuery
+                ->select(DB::raw(1))
+                ->from("{$helperTable} as base")
+                ->join("{$helperTable} as fallback", function (JoinClause $join) use ($helperModelForeignKey) {
+                    $join
+                        ->on('fallback.' . $helperModelForeignKey, '=', 'base.' . $helperModelForeignKey)
+                        ->on('fallback.language', '=', 'base.fallback_language');
+                })
+                ->whereColumn('base.' . $helperModelForeignKey, $this->qualifyColumn('id'))
+                ->where('base.language', App::getLocale())
+                ->where(is_string($column) ? "fallback.$column" : $column, $operator, $value);
+        });
+    }
+
+    public function scopeOrWhereFallbackTranslation(
+        Builder $query,
+        Closure | string | array | Expression $column,
+        mixed $operator = null,
+        mixed $value = null,
+    ): Builder {
+        return $this->scopeWhereFallbackTranslation($query, $column, $operator, $value, 'or');
+    }
+
     public function resolveRouteBinding($value, $field = null): ?Model
     {
         $field ??= $this->getRouteKeyName();
@@ -195,6 +244,7 @@ trait HelperModelTranslatable
         if ($this->isTranslatableAttribute($field)) {
             return $this
                 ->whereTranslation($field, '=', $value, App::getLocale())
+                ->orWhereFallbackTranslation($field, '=', $value)
                 ->first();
         }
 

--- a/src/HelperModelTranslatable.php
+++ b/src/HelperModelTranslatable.php
@@ -249,8 +249,11 @@ trait HelperModelTranslatable
 
         if ($this->isTranslatableAttribute($field)) {
             return $this
-                ->whereTranslation($field, '=', $value, App::getLocale())
-                ->orWhereFallbackTranslation($field, '=', $value)
+                ->where(function (Builder $query) use ($field, $value) {
+                    $query
+                        ->whereTranslation($field, '=', $value, App::getLocale())
+                        ->orWhereFallbackTranslation($field, '=', $value);
+                })
                 ->first();
         }
 

--- a/tests/HelperModelTranslatableTest.php
+++ b/tests/HelperModelTranslatableTest.php
@@ -449,4 +449,98 @@ final class HelperModelTranslatableTest extends TestCase
         $this->assertTrue($posts->contains($postA));
         $this->assertTrue($posts->contains($postB));
     }
+
+    #[Test]
+    public function it_can_get_the_fallback_locale_from_the_translation_model(): void
+    {
+        $post = Post::create();
+        $this->createPostTranslation($post, 'nl', ['title' => 'Post nl', 'fallback_language' => 'en']);
+        $this->createPostTranslation($post, 'en', ['title' => 'Post en', 'fallback_language' => 'nl']);
+
+        App::setLocale('nl');
+        $this->assertEquals('en', $post->getFallbackLocale('nl'));
+
+        App::setLocale('en');
+        $this->assertEquals('nl', $post->getFallbackLocale('en'));
+    }
+
+    #[Test]
+    public function it_falls_back_to_app_fallback_locale_when_no_fallback_language_defined(): void
+    {
+        $post = Post::create();
+        $this->createPostTranslation($post, 'nl', ['title' => 'Post nl']);
+
+        $this->assertEquals(config('app.fallback_locale'), $post->getFallbackLocale('nl'));
+    }
+
+    #[Test]
+    public function it_can_get_a_translation_using_database_defined_fallback(): void
+    {
+        $post = Post::create();
+        $this->createPostTranslation($post, 'nl', ['title' => 'Post nl', 'fallback_language' => 'fr']);
+        $this->createPostTranslation($post, 'fr', ['title' => 'Post fr']);
+        $this->createPostTranslation($post, 'de', ['title' => null, 'fallback_language' => 'fr']);
+
+        $this->assertEquals('Post nl', $post->getTranslationWithFallback('title', 'nl'));
+        $this->assertEquals('Post fr', $post->getTranslationWithFallback('title', 'de'));
+    }
+
+    #[Test]
+    public function it_can_use_the_where_fallback_translation_scope(): void
+    {
+        $postA = Post::create();
+        $postB = Post::create();
+        $this->createPostTranslation($postA, 'en', ['title' => null, 'slug' => null, 'fallback_language' => 'nl']);
+        $this->createPostTranslation($postA, 'nl', ['title' => 'Post nl', 'slug' => 'post-nl', 'fallback_language' => 'en']);
+        $this->createPostTranslation($postB, 'en', ['title' => 'Other post', 'slug' => 'other-post']);
+
+        App::setLocale('en');
+        $posts = Post::whereFallbackTranslation('title', '=', 'Post nl')->get();
+
+        $this->assertTrue($posts->contains($postA));
+        $this->assertFalse($posts->contains($postB));
+    }
+
+    #[Test]
+    public function it_can_use_the_or_where_fallback_translation_scope(): void
+    {
+        $postA = Post::create();
+        $postB = Post::create();
+        $this->createPostTranslation($postA, 'en', ['title' => 'Post en']);
+        $this->createPostTranslation($postB, 'en', ['title' => null, 'fallback_language' => 'nl']);
+        $this->createPostTranslation($postB, 'nl', ['title' => 'Post nl', 'fallback_language' => 'en']);
+
+        App::setLocale('en');
+        $posts = Post::whereTranslation('title', '=', 'Post en', 'en')
+            ->orWhereFallbackTranslation('title', '=', 'Post nl')
+            ->get();
+
+        $this->assertTrue($posts->contains($postA));
+        $this->assertTrue($posts->contains($postB));
+    }
+
+    #[Test]
+    public function it_can_resolve_route_binding_with_fallback_translation(): void
+    {
+        $post = Post::create();
+        $this->createPostTranslation($post, 'en', ['title' => 'Post en', 'slug' => null, 'fallback_language' => 'nl']);
+        $this->createPostTranslation($post, 'nl', ['title' => 'Post nl', 'slug' => 'post-nl', 'fallback_language' => 'en']);
+
+        App::setLocale('en');
+        $this->get('/post-nl')->assertSee('Post en');
+    }
+
+    #[Test]
+    public function it_prefers_current_locale_over_fallback_in_route_binding(): void
+    {
+        $postA = Post::create();
+        $postB = Post::create();
+        $this->createPostTranslation($postA, 'en', ['title' => 'Post en', 'slug' => 'post', 'fallback_language' => 'nl']);
+        $this->createPostTranslation($postA, 'nl', ['title' => 'Post nl', 'slug' => 'post-nl', 'fallback_language' => 'en']);
+        $this->createPostTranslation($postB, 'en', ['title' => null, 'slug' => null, 'fallback_language' => 'nl']);
+        $this->createPostTranslation($postB, 'nl', ['title' => 'Post B nl', 'slug' => 'post', 'fallback_language' => 'en']);
+
+        App::setLocale('en');
+        $this->get('/post')->assertSee('Post en');
+    }
 }

--- a/tests/HelperModelTranslatableTest.php
+++ b/tests/HelperModelTranslatableTest.php
@@ -163,6 +163,8 @@ final class HelperModelTranslatableTest extends TestCase
     #[Test]
     public function it_can_get_the_translation_model_using_a_fallback(): void
     {
+        Config::set('app.fallback_locale', 'en');
+
         $post = Post::create();
         $postTranslationEn = $this->createPostTranslation($post, 'en', ['title' => 'Test en']);
 

--- a/tests/HelperModelTranslatableTest.php
+++ b/tests/HelperModelTranslatableTest.php
@@ -22,11 +22,11 @@ final class HelperModelTranslatableTest extends TestCase
 
     protected function createPostTranslation(
         Model $post,
-        string $language,
+        string $locale,
         array $attributes = []
     ): PostTranslation {
         return PostTranslation::create(array_merge(
-            ['post_id' => $post->id, 'language' => $language],
+            ['post_id' => $post->id, 'locale' => $locale],
             $attributes,
         ));
     }
@@ -454,8 +454,8 @@ final class HelperModelTranslatableTest extends TestCase
     public function it_can_get_the_fallback_locale_from_the_translation_model(): void
     {
         $post = Post::create();
-        $this->createPostTranslation($post, 'nl', ['title' => 'Post nl', 'fallback_language' => 'en']);
-        $this->createPostTranslation($post, 'en', ['title' => 'Post en', 'fallback_language' => 'nl']);
+        $this->createPostTranslation($post, 'nl', ['title' => 'Post nl', 'fallback_locale' => 'en']);
+        $this->createPostTranslation($post, 'en', ['title' => 'Post en', 'fallback_locale' => 'nl']);
 
         App::setLocale('nl');
         $this->assertEquals('en', $post->getFallbackLocale('nl'));
@@ -465,7 +465,7 @@ final class HelperModelTranslatableTest extends TestCase
     }
 
     #[Test]
-    public function it_falls_back_to_app_fallback_locale_when_no_fallback_language_defined(): void
+    public function it_falls_back_to_app_fallback_locale_when_no_fallback_locale_defined(): void
     {
         $post = Post::create();
         $this->createPostTranslation($post, 'nl', ['title' => 'Post nl']);
@@ -477,9 +477,9 @@ final class HelperModelTranslatableTest extends TestCase
     public function it_can_get_a_translation_using_database_defined_fallback(): void
     {
         $post = Post::create();
-        $this->createPostTranslation($post, 'nl', ['title' => 'Post nl', 'fallback_language' => 'fr']);
+        $this->createPostTranslation($post, 'nl', ['title' => 'Post nl', 'fallback_locale' => 'fr']);
         $this->createPostTranslation($post, 'fr', ['title' => 'Post fr']);
-        $this->createPostTranslation($post, 'de', ['title' => null, 'fallback_language' => 'fr']);
+        $this->createPostTranslation($post, 'de', ['title' => null, 'fallback_locale' => 'fr']);
 
         $this->assertEquals('Post nl', $post->getTranslationWithFallback('title', 'nl'));
         $this->assertEquals('Post fr', $post->getTranslationWithFallback('title', 'de'));
@@ -490,8 +490,8 @@ final class HelperModelTranslatableTest extends TestCase
     {
         $postA = Post::create();
         $postB = Post::create();
-        $this->createPostTranslation($postA, 'en', ['title' => null, 'slug' => null, 'fallback_language' => 'nl']);
-        $this->createPostTranslation($postA, 'nl', ['title' => 'Post nl', 'slug' => 'post-nl', 'fallback_language' => 'en']);
+        $this->createPostTranslation($postA, 'en', ['title' => null, 'slug' => null, 'fallback_locale' => 'nl']);
+        $this->createPostTranslation($postA, 'nl', ['title' => 'Post nl', 'slug' => 'post-nl', 'fallback_locale' => 'en']);
         $this->createPostTranslation($postB, 'en', ['title' => 'Other post', 'slug' => 'other-post']);
 
         App::setLocale('en');
@@ -507,8 +507,8 @@ final class HelperModelTranslatableTest extends TestCase
         $postA = Post::create();
         $postB = Post::create();
         $this->createPostTranslation($postA, 'en', ['title' => 'Post en']);
-        $this->createPostTranslation($postB, 'en', ['title' => null, 'fallback_language' => 'nl']);
-        $this->createPostTranslation($postB, 'nl', ['title' => 'Post nl', 'fallback_language' => 'en']);
+        $this->createPostTranslation($postB, 'en', ['title' => null, 'fallback_locale' => 'nl']);
+        $this->createPostTranslation($postB, 'nl', ['title' => 'Post nl', 'fallback_locale' => 'en']);
 
         App::setLocale('en');
         $posts = Post::whereTranslation('title', '=', 'Post en', 'en')
@@ -523,8 +523,8 @@ final class HelperModelTranslatableTest extends TestCase
     public function it_can_resolve_route_binding_with_fallback_translation(): void
     {
         $post = Post::create();
-        $this->createPostTranslation($post, 'en', ['title' => 'Post en', 'slug' => null, 'fallback_language' => 'nl']);
-        $this->createPostTranslation($post, 'nl', ['title' => 'Post nl', 'slug' => 'post-nl', 'fallback_language' => 'en']);
+        $this->createPostTranslation($post, 'en', ['title' => 'Post en', 'slug' => null, 'fallback_locale' => 'nl']);
+        $this->createPostTranslation($post, 'nl', ['title' => 'Post nl', 'slug' => 'post-nl', 'fallback_locale' => 'en']);
 
         App::setLocale('en');
         $this->get('/post-nl')->assertSee('Post en');
@@ -535,10 +535,10 @@ final class HelperModelTranslatableTest extends TestCase
     {
         $postA = Post::create();
         $postB = Post::create();
-        $this->createPostTranslation($postA, 'en', ['title' => 'Post en', 'slug' => 'post', 'fallback_language' => 'nl']);
-        $this->createPostTranslation($postA, 'nl', ['title' => 'Post nl', 'slug' => 'post-nl', 'fallback_language' => 'en']);
-        $this->createPostTranslation($postB, 'en', ['title' => null, 'slug' => null, 'fallback_language' => 'nl']);
-        $this->createPostTranslation($postB, 'nl', ['title' => 'Post B nl', 'slug' => 'post', 'fallback_language' => 'en']);
+        $this->createPostTranslation($postA, 'en', ['title' => 'Post en', 'slug' => 'post', 'fallback_locale' => 'nl']);
+        $this->createPostTranslation($postA, 'nl', ['title' => 'Post nl', 'slug' => 'post-nl', 'fallback_locale' => 'en']);
+        $this->createPostTranslation($postB, 'en', ['title' => null, 'slug' => null, 'fallback_locale' => 'nl']);
+        $this->createPostTranslation($postB, 'nl', ['title' => 'Post B nl', 'slug' => 'post', 'fallback_locale' => 'en']);
 
         App::setLocale('en');
         $this->get('/post')->assertSee('Post en');

--- a/tests/HelperModelTranslatableTest.php
+++ b/tests/HelperModelTranslatableTest.php
@@ -454,13 +454,9 @@ final class HelperModelTranslatableTest extends TestCase
     public function it_can_get_the_fallback_locale_from_the_translation_model(): void
     {
         $post = Post::create();
-        $this->createPostTranslation($post, 'nl', ['title' => 'Post nl', 'fallback_locale' => 'en']);
+        $this->createPostTranslation($post, 'nl', ['title' => 'Post nl']);
         $this->createPostTranslation($post, 'en', ['title' => 'Post en', 'fallback_locale' => 'nl']);
 
-        App::setLocale('nl');
-        $this->assertEquals('en', $post->getFallbackLocale('nl'));
-
-        App::setLocale('en');
         $this->assertEquals('nl', $post->getFallbackLocale('en'));
     }
 
@@ -477,7 +473,7 @@ final class HelperModelTranslatableTest extends TestCase
     public function it_can_get_a_translation_using_database_defined_fallback(): void
     {
         $post = Post::create();
-        $this->createPostTranslation($post, 'nl', ['title' => 'Post nl', 'fallback_locale' => 'fr']);
+        $this->createPostTranslation($post, 'nl', ['title' => 'Post nl']);
         $this->createPostTranslation($post, 'fr', ['title' => 'Post fr']);
         $this->createPostTranslation($post, 'de', ['title' => null, 'fallback_locale' => 'fr']);
 
@@ -491,7 +487,7 @@ final class HelperModelTranslatableTest extends TestCase
         $postA = Post::create();
         $postB = Post::create();
         $this->createPostTranslation($postA, 'en', ['title' => null, 'slug' => null, 'fallback_locale' => 'nl']);
-        $this->createPostTranslation($postA, 'nl', ['title' => 'Post nl', 'slug' => 'post-nl', 'fallback_locale' => 'en']);
+        $this->createPostTranslation($postA, 'nl', ['title' => 'Post nl', 'slug' => 'post-nl']);
         $this->createPostTranslation($postB, 'en', ['title' => 'Other post', 'slug' => 'other-post']);
 
         App::setLocale('en');
@@ -508,7 +504,7 @@ final class HelperModelTranslatableTest extends TestCase
         $postB = Post::create();
         $this->createPostTranslation($postA, 'en', ['title' => 'Post en']);
         $this->createPostTranslation($postB, 'en', ['title' => null, 'fallback_locale' => 'nl']);
-        $this->createPostTranslation($postB, 'nl', ['title' => 'Post nl', 'fallback_locale' => 'en']);
+        $this->createPostTranslation($postB, 'nl', ['title' => 'Post nl']);
 
         App::setLocale('en');
         $posts = Post::whereTranslation('title', '=', 'Post en', 'en')
@@ -524,7 +520,7 @@ final class HelperModelTranslatableTest extends TestCase
     {
         $post = Post::create();
         $this->createPostTranslation($post, 'en', ['title' => 'Post en', 'slug' => null, 'fallback_locale' => 'nl']);
-        $this->createPostTranslation($post, 'nl', ['title' => 'Post nl', 'slug' => 'post-nl', 'fallback_locale' => 'en']);
+        $this->createPostTranslation($post, 'nl', ['title' => 'Post nl', 'slug' => 'post-nl']);
 
         App::setLocale('en');
         $this->get('/post-nl')->assertSee('Post en');
@@ -535,10 +531,10 @@ final class HelperModelTranslatableTest extends TestCase
     {
         $postA = Post::create();
         $postB = Post::create();
-        $this->createPostTranslation($postA, 'en', ['title' => 'Post en', 'slug' => 'post', 'fallback_locale' => 'nl']);
-        $this->createPostTranslation($postA, 'nl', ['title' => 'Post nl', 'slug' => 'post-nl', 'fallback_locale' => 'en']);
+        $this->createPostTranslation($postA, 'en', ['title' => 'Post en', 'slug' => 'post']);
+        $this->createPostTranslation($postA, 'nl', ['title' => 'Post nl', 'slug' => 'post-nl']);
         $this->createPostTranslation($postB, 'en', ['title' => null, 'slug' => null, 'fallback_locale' => 'nl']);
-        $this->createPostTranslation($postB, 'nl', ['title' => 'Post B nl', 'slug' => 'post', 'fallback_locale' => 'en']);
+        $this->createPostTranslation($postB, 'nl', ['title' => 'Post B nl', 'slug' => 'post']);
 
         App::setLocale('en');
         $this->get('/post')->assertSee('Post en');

--- a/tests/HelperModelTranslatableTest.php
+++ b/tests/HelperModelTranslatableTest.php
@@ -161,6 +161,16 @@ final class HelperModelTranslatableTest extends TestCase
     }
 
     #[Test]
+    public function it_can_get_the_translation_model_using_a_fallback(): void
+    {
+        $post = Post::create();
+        $postTranslationEn = $this->createPostTranslation($post, 'en', ['title' => 'Test en']);
+
+        $this->assertTrue($post->getTranslationModel('fr', true)->is($postTranslationEn));
+        $this->assertNull($post->getTranslationModel('fr', false));
+    }
+
+    #[Test]
     public function it_can_get_a_translation_using_a_fallback(): void
     {
         $post = Post::create();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -49,8 +49,8 @@ abstract class TestCase extends BaseTestCase
 
         Schema::create('post_translations', function (Blueprint $table) {
             $table->id();
-            $table->string('language', 5);
-            $table->string('fallback_language', 5)->nullable();
+            $table->string('locale', 5);
+            $table->string('fallback_locale', 5)->nullable();
             $table->foreignId('post_id')->constrained('posts');
             $table->string('title')->nullable();
             $table->string('slug')->nullable();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -50,6 +50,7 @@ abstract class TestCase extends BaseTestCase
         Schema::create('post_translations', function (Blueprint $table) {
             $table->id();
             $table->string('language', 5);
+            $table->string('fallback_language', 5)->nullable();
             $table->foreignId('post_id')->constrained('posts');
             $table->string('title')->nullable();
             $table->string('slug')->nullable();


### PR DESCRIPTION
## Summary

Introduces a new way of defining fallback translations directly on the helpermodel translation tables via a `fallback_locale` column, instead of relying solely on the application config. Also renames the `language` column to `locale`.

## Changes

- **Renamed `language` to `locale`** — The column on translation tables is now expected to be named `locale`.
- **`scopeWhereFallbackTranslation`** / **`scopeOrWhereFallbackTranslation`** — New query scopes that use a `whereExists` subquery with a self-join on the translations table (`base.fallback_locale = fallback.locale`) to find models via their database-defined fallback.
- **`getFallbackLocale()`** — Now reads `fallback_locale` from the translation model first, falling back to `config('app.fallback_locale')` when not defined.
- **`resolveRouteBinding()`** — Updated to use `orWhereFallbackTranslation` so route model binding automatically resolves via the fallback chain.

## Usage

Add a `fallback_locale` column to your translation tables:

```php
$table->string('fallback_locale', 5)->nullable();
```

Example data:
```json
{"id": 1, "page_id": 1, "locale": "nl-be", "fallback_locale": null, "title": "Home"}
{"id": 2, "page_id": 1, "locale": "nl-nl", "fallback_locale": "nl-be", "title": null}
```

The main locale does not define a `fallback_locale`. Only secondary locales that need to fall back to another locale should have this column set.